### PR TITLE
Feature/compound iteration targets

### DIFF
--- a/docs/collapse_literals.rst
+++ b/docs/collapse_literals.rst
@@ -43,6 +43,27 @@ If a branch is constant, and thus known at decoration time, then only the correc
 
 This decorator is actually very powerful, understanding any definition-time known collections, primitives, or even dictionaries. Subscripts are resolved if the list or dictionary, and the key into it, can be resolved. Names are replaced by their values if they are not containers (since re-writing a container, such as a tuple or list, could duplicate object references). Functions, such as ``len`` and ``sum`` can be computed and replaced with their value if their arguments are known.
 
+Only primitive types are resolved, and this does not include iterable types. To control this behavior, use the `collapse_iterables` argument. Example:
+
+    v = [1, 2]
+
+    @pragma.collapse_literals
+    def f():
+        yield v
+
+    # ^ nothing happens ^
+
+    @pragma.collapse_literals(collapse_iterables=True)
+    def f():
+        yield v
+
+    # ... Becomes ...
+
+    def f():
+        yield [1, 2]
+
+There are cases where you don't want to collapse all literals. It often happens when you have lots of global variables and long functions, or if you want to apply different pragma patterns to different parts of the function. Fine control is possible with the `explicit_only` argument. When True, only explicit keyword arguments and the value of the `function_globals` argument (itself a dictionary) are collapsed.
+
 .. todo:: Always commit changes within a block, and only mark values as non-deterministic outside of conditional blocks
 .. todo:: Support list/set/dict comprehensions
 .. todo:: Attributes are too iffy, since properties abound, but assignment to a known index of a known indexable should be remembered

--- a/docs/unroll.rst
+++ b/docs/unroll.rst
@@ -84,6 +84,41 @@ The ``unroll`` decorator accomplishes this by parsing the input function, perfor
         yield 2 + 1
         yield 2 + 2
 
+``unroll`` also supports tuple-target interation with ``enumerate``, ``zip``, and ``items``::
+
+    v = [1, 3, 5]
+
+    @pragma.unroll
+    def f():
+        for i, elem in enumerate(v):
+            yield i, elem
+
+    # ... Becomes ...
+
+    def f():
+        yield 0, 1
+        yield 1, 3
+        yield 2, 5
+
+When combined with ``deindex``, ``unroll`` can also handle cases where the values being iterated over are not literals. The decorators must be in this order (deindex being applied before unroll), and the ``collapse_iterables`` argument is necessary::
+
+    d = {'a': object(), 'b': object()}
+
+    @pragma.unroll
+    @pragma.deindex(d, 'd', collapse_iterables=True)
+    def f():
+        for k, v in d.items():
+            yield k
+            yield v
+
+    # ... Becomes ...
+
+    def f():
+        yield 'a'
+        yield d_a
+        yield 'b'
+        yield d_b
+
 Also supported are recognizing top-level breaks. Breaks inside conditionals aren't yet supported, though they could eventually be by combining unrolling with literal condition collapsing::
 
     @pragma.unroll

--- a/pragma/core/resolve/__init__.py
+++ b/pragma/core/resolve/__init__.py
@@ -89,13 +89,13 @@ except ImportError:  # pragma: nocover
     float_types = (float,)
 
 primitive_types = tuple([str, bytes, bool, type(None)] + list(num_types) + list(float_types))
-iterable_types = (list, tuple)
+iterable_types = (list, tuple, dict)
 
 try:
     primitive_ast_types = (ast.Num, ast.Str, ast.Bytes, ast.NameConstant, ast.Constant, ast.JoinedStr)
 except AttributeError:  # Python <3.6
     primitive_ast_types = (ast.Num, ast.Str, ast.Bytes, ast.NameConstant)
-iterable_ast_types = (ast.List, ast.Tuple)
+iterable_ast_types = (ast.List, ast.Tuple, ast.Dict)
 
 
 def make_binop(op):

--- a/pragma/core/resolve/iterable.py
+++ b/pragma/core/resolve/iterable.py
@@ -76,7 +76,7 @@ def _resolve_mappable_keysvaluesitems(node, ctxt):
     elif node.func.attr == 'items':
         return tuple(base_obj.items())
     else:
-        log.debug('Could not resolve {} of {} as map iterator'.format(node.func.attr, base_obj))
+        log.debug('Could not resolve {} of {} as map iterator'.format(node.func.attr, base_obj))  #  deepcode ignore W1202
         return node
 
 

--- a/pragma/core/resolve/iterable.py
+++ b/pragma/core/resolve/iterable.py
@@ -60,6 +60,26 @@ def _resolve_iterable_set_or_dict(node, ctxt):
     return iter(set(vals))
 
 
+def _resolve_mappable_keysvaluesitems(node, ctxt):
+    ''' Resolves things like dct.keys() and dct.items()
+        if the keys of the dct are all literals
+    '''
+    if not isinstance(node.func, ast.Attribute):
+        return node
+    base_obj = resolve_literal(node.func.value, ctxt, give_raw_result=True)
+    if isinstance(base_obj, ast.AST):
+        return node
+    if node.func.attr == 'keys':
+        return tuple(base_obj.keys())
+    elif node.func.attr == 'values':
+        return tuple(base_obj.values())
+    elif node.func.attr == 'items':
+        return tuple(base_obj.items())
+    else:
+        log.debug('Could not resolve {} of {} as map iterator'.format(node.func.attr, base_obj))
+        return node
+
+
 def _resolve_iterable_list_or_tuple(node, ctxt):
     return node.elts
 
@@ -99,6 +119,10 @@ def _resolve_iterable(node, ctxt):
         return _resolve_iterable_binop(node, ctxt)
 
     elif isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Attribute):
+            result = _resolve_mappable_keysvaluesitems(node, ctxt)
+            if result != node:
+                return result
         return _resolve_iterable_call(node, ctxt)
 
     elif isinstance(node, (ast.Set, ast.Dict)):

--- a/pragma/core/resolve/literal.py
+++ b/pragma/core/resolve/literal.py
@@ -6,7 +6,7 @@ import warnings
 from miniutils import magic_contract
 
 from .. import _log_call, DictStack
-from . import CollapsableNode, primitive_ast_types, iterable_ast_types
+from . import CollapsableNode, primitive_types, primitive_ast_types, iterable_ast_types
 
 log = logging.getLogger(__name__)
 
@@ -174,8 +174,12 @@ def resolve_literal_subscript(node, ctxt):
             try:
                 if isinstance(indexable, dict):
                     indexable = {_resolve_literal(k, ctxt): v for k, v in indexable.items()}
-                # return _resolve_literal(indexable[slice], ctxt)
-                return indexable[slice]
+                item = indexable[slice]
+                res = _resolve_literal(item, ctxt)
+                if isinstance(res, primitive_types):
+                    return res
+                else:
+                    return item
             except (KeyError, IndexError):
                 log.debug("Cannot index {}[{}]".format(indexable, slice))
                 return node

--- a/pragma/deindex.py
+++ b/pragma/deindex.py
@@ -25,7 +25,16 @@ def deindex(iterable, iterable_name, *args, **kwargs):
     """
 
     if hasattr(iterable, 'items'):  # Support dicts and the like
-        internal_iterable = {k: '{}_{}'.format(iterable_name, k) for k, val in iterable.items()}
+        sanitized_map = {}
+        invalid_chars = [' ', '-', '+', '/', '\\', '.', '!', '@', '#', '$', '%', ':', '?']
+        for k in iterable.keys():
+            if isinstance(k, int):
+                sanitized_map[k] = k
+            elif isinstance(k, str) and not any(ic in k for ic in invalid_chars):
+                sanitized_map[k] = k
+            else:
+                sanitized_map[k] = abs(hash(str(k)))
+        internal_iterable = {k: '{}_{}'.format(iterable_name, sk) for k, sk in sanitized_map.items()}
         mapping = {internal_iterable[k]: val for k, val in iterable.items()}
         ast_iterable = {k: ast.Name(id=name, ctx=ast.Load()) for k, name in internal_iterable.items()}
     else:  # Support lists, tuples, and the like

--- a/pragma/deindex.py
+++ b/pragma/deindex.py
@@ -44,7 +44,7 @@ def deindex(iterable, iterable_name, *args, **kwargs):
     # attempt to make the ast_iterable the same type as the original, otherwise keep it the builtin type
     try:
         ast_iterable = type(iterable)(ast_iterable)
-    except:
+    except Exception:  #  deepcode ignore W0703: Generic exception
         pass
     kwargs[iterable_name] = ast_iterable
     mapping[iterable_name] = iterable

--- a/pragma/unroll.py
+++ b/pragma/unroll.py
@@ -92,6 +92,13 @@ class UnrollTransformer(TrackedContextTransformer):
             raise NameError("'{}' not defined in context".format(node.id))
         return node
 
+    def visit_Subscript(self, node):
+        # resolve only if node is an ast.Name in our loop_vars
+        if (isinstance(node.value, ast.Name) and isinstance(node.value.ctx, ast.Load)
+                and self.loop_vars and node.value.id in set.union(*self.loop_vars)):
+            return self.resolve_literal(self.generic_visit(node))
+        return self.generic_visit(node)
+
 
 # Unroll literal loops
 unroll = make_function_transformer(UnrollTransformer, 'unroll', "Unrolls constant loops in the decorated function")

--- a/pragma/unroll.py
+++ b/pragma/unroll.py
@@ -1,4 +1,8 @@
-from .core import *
+import ast
+import copy
+import logging
+import warnings
+from .core import TrackedContextTransformer, make_function_transformer, make_ast_from_literal
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +65,7 @@ class UnrollTransformer(TrackedContextTransformer):
             try:
                 val = make_ast_from_literal(val)
             except TypeError:
-                log.debug("Failed to unroll loop, {} failed to convert to AST".format(val))
+                log.debug("Failed to unroll loop, %s failed to convert to AST", val)
                 return self.generic_visit(node)
             self.loop_vars.append(set(self.assign(node.target, val)))
             for body_node in copy.deepcopy(node.body):

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 setup(
     name='pragma',
-    version='0.2.0',
-    packages=['pragma', 'pragma.core'],
+    version='0.2.1',
+    packages=['pragma', 'pragma.core', 'pragma.core.resolve'],
     url='https://github.com/scnerd/pypragma',
     license='MIT',
     author='scnerd',
@@ -13,5 +13,6 @@ setup(
     install_requires=[
         'miniutils',
         'astor',
+        'nose'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,5 @@ setup(
     install_requires=[
         'miniutils',
         'astor',
-        'nose'
     ]
 )

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -1,3 +1,5 @@
+# file deepcode ignore E0602: Ignore undefined variables because they never go live if just converting function string
+# file deepcode ignore E0102: Ignore function names that are redefined, such as f(x)
 from textwrap import dedent
 
 import pragma

--- a/tests/test_deindex.py
+++ b/tests/test_deindex.py
@@ -104,7 +104,7 @@ class TestDeindex(PragmaTest):
 
         self.assertSourceEqual(f, result)
 
-    def test_dict(self):
+    def test_deindex_dict(self):
         d = {'a': 1, 'b': 2}
 
         @pragma.deindex(d, 'd')
@@ -117,11 +117,70 @@ class TestDeindex(PragmaTest):
             yield d_a
             yield d[x]
         '''
+        roundtrip_result = '''
+        def f(x):
+            yield 1
+            yield d[x]
+        '''
 
         self.assertSourceEqual(f, result)
+        self.assertSourceEqual(pragma.collapse_literals(f), roundtrip_result)
         d = {'a': 3, 'b': 4}  # should have no effect because the value of d was frozen at declaration time
         self.assertListEqual(list(f('a')), [1, 1])
         self.assertListEqual(list(f('b')), [1, 2])
+
+    def test_deindex_dict_special_keys(self):
+        d = {(15, 20): 1, ('x', 1): 2, 'hyphen-key': 3, 1.25e3: 4, 'regular_key': 5}
+        keyhashes = [abs(hash(str(k))) for k in d.keys()]
+
+        @pragma.deindex(d, 'd')
+        def f(x):
+            yield d[(15, 20)]
+            yield d[('x', 1)]
+            yield d['hyphen-key']
+            yield d[1.25e3]
+            yield d['regular_key']
+            yield d[x]
+
+        result = '''
+        def f(x):
+            {}
+            yield d_regular_key
+            yield d[x]
+        '''.format('\n            '.join('yield d_' + str(h) for h in keyhashes[:-1]))
+        roundtrip_result = '''
+        def f(x):
+            yield 1
+            yield 2
+            yield 3
+            yield 4
+            yield 5
+            yield d[x]
+        '''
+
+        self.assertSourceEqual(f, result)
+        self.assertSourceEqual(pragma.collapse_literals(f), roundtrip_result)
+        self.assertListEqual(list(f((15, 20))), [1, 2, 3, 4, 5, 1])
+        self.assertListEqual(list(f('hyphen-key')), [1, 2, 3, 4, 5, 3])
+
+    # def test_dict_nonliteral_keys(self):
+    #     d = {'a': 1, 'b': 2}
+
+    #     @pragma.deindex(d, 'd')
+    #     def f(x):
+    #         yield d['a']
+    #         yield d[x]
+
+    #     result = '''
+    #     def f(x):
+    #         yield d_a
+    #         yield d[x]
+    #     '''
+
+    #     self.assertSourceEqual(f, result)
+    #     d = {'a': 3, 'b': 4}  # should have no effect because the value of d was frozen at declaration time
+    #     self.assertListEqual(list(f('a')), [1, 1])
+    #     self.assertListEqual(list(f('b')), [1, 2])
 
     def test_different_name(self):
         d = {'a': 1, 'b': 2}

--- a/tests/test_deindex.py
+++ b/tests/test_deindex.py
@@ -1,3 +1,5 @@
+# file deepcode ignore E0602: Ignore undefined variables because they never go live if just converting function string
+# file deepcode ignore E0102: Ignore function names that are redefined, such as f(x)
 import inspect
 from textwrap import dedent
 
@@ -140,7 +142,7 @@ class TestDeindex(PragmaTest):
 
     def test_deindex_dict_special_keys(self):
         d = {(15, 20): 1, ('x', 1): 2, 'hyphen-key': 3, 1.25e3: 4, 'regular_key': 5}
-        keyhashes = [abs(hash(str(k))) for k in d.keys()]
+        keyhashes = [abs(hash(str(k))) for k in d]
 
         @pragma.deindex(d, 'd')
         def f(x):
@@ -164,25 +166,6 @@ class TestDeindex(PragmaTest):
         self.assertSourceEqual(f, result)
         self.assertListEqual(list(f((15, 20))), [1, 2, 3, 4, 5, 1])
         self.assertListEqual(list(f('hyphen-key')), [1, 2, 3, 4, 5, 3])
-
-    # def test_dict_nonliteral_keys(self):
-    #     d = {'a': 1, 'b': 2}
-
-    #     @pragma.deindex(d, 'd')
-    #     def f(x):
-    #         yield d['a']
-    #         yield d[x]
-
-    #     result = '''
-    #     def f(x):
-    #         yield d_a
-    #         yield d[x]
-    #     '''
-
-    #     self.assertSourceEqual(f, result)
-    #     d = {'a': 3, 'b': 4}  # should have no effect because the value of d was frozen at declaration time
-    #     self.assertListEqual(list(f('a')), [1, 1])
-    #     self.assertListEqual(list(f('b')), [1, 2])
 
     def test_different_name(self):
         d = {'a': 1, 'b': 2}

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -332,3 +332,21 @@ class TestUnroll(PragmaTest):
         '''
 
         self.assertSourceEqual(f, result)
+
+    def test_enumerate(self):
+        v = [0, 3, object()]
+
+        @pragma.unroll
+        @pragma.deindex(v, 'v', collapse_iterables=True)
+        def f():
+            for i, elem in enumerate(v):
+                yield i, elem
+
+        result = '''
+        def f():
+            yield 0, 0
+            yield 1, 3
+            yield 2, v_2
+        '''
+
+        self.assertSourceEqual(f, result)

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -352,6 +352,8 @@ class TestUnroll(PragmaTest):
         self.assertSourceEqual(f, result)
 
     def test_dict_items(self):
+        if not dict_order_maintained:
+            raise SkipTest()
         d = {'a': 1, 'b': 2}
 
         @pragma.unroll
@@ -372,6 +374,8 @@ class TestUnroll(PragmaTest):
         self.assertListEqual(list(f()), ['a', 1, 'b', 2])
 
     def test_nonliteral_dict_items(self):
+        if not dict_order_maintained:
+            raise SkipTest()
         d = {'a': object(), 'b': object()}
 
         @pragma.unroll
@@ -393,6 +397,8 @@ class TestUnroll(PragmaTest):
         self.assertListEqual(list(f()), ['a', d['a'], 'b', d['b']])
 
     def test_unroll_special_dict(self):
+        if not dict_order_maintained:
+            raise SkipTest()
         d = {(15, 20): 1, ('x', 1): 2, 'hyphen-key': 3, 1.25e3: 4, 'regular_key': 5}
 
         @pragma.unroll

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -350,3 +350,32 @@ class TestUnroll(PragmaTest):
         '''
 
         self.assertSourceEqual(f, result)
+    def test_unroll_zip(self):
+        a = [1, 2]
+        b = [10, 20]
+
+        # assign multiple values
+        @pragma.unroll
+        def f():
+            for _a, _b in zip(a, b):
+                yield _a
+                yield _b
+
+        result = '''
+        def f():
+            yield 1
+            yield 10
+            yield 2
+            yield 20
+        '''
+        self.assertSourceEqual(f, result)
+
+        # assign to a single variable representing a tuple, then deindex
+        @pragma.unroll
+        def f():
+            for z in zip(a, b):
+                yield z[0]
+                yield z[1]
+
+        self.assertSourceEqual(f, result)
+        self.assertListEqual(list(f()), [1, 10, 2, 20])

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -1,7 +1,13 @@
+# file deepcode ignore E0602: Ignore undefined variables because they never go live if just converting function string
+# file deepcode ignore E0102: Ignore function names that are redefined, such as f(x)
 from textwrap import dedent
+from unittest import SkipTest
+import sys
 
 import pragma
 from .test_pragma import PragmaTest
+
+dict_order_maintained = (sys.version_info.minor >= 6)
 
 
 class TestUnroll(PragmaTest):


### PR DESCRIPTION
## Unroll
Support for `zip`, `enumerate`, and `dict.items()` such as
```python
for k, v in mydict.items():
    yield k
    yield v
```

## Deindex
Sanitizing dict keys, such as in `{'strange-key?!': 1, (1, 'x'): 2}`

## Collapse literals
Can resolve dictionaries if the keys can be made literal. Non-primitive values are allowed but remain AST.

This does not affect current behavior of `pragma.collapse_literals` unless the `collapse_iterables` argument is `True`. Mainly, this is used in cases where we are iterating over dictionary values or items.