### PR TITLE
Feature/unroll on lhs

### DIFF
--- a/docs/collapse_literals.rst
+++ b/docs/collapse_literals.rst
@@ -64,6 +64,8 @@ Only primitive types are resolved, and this does not include iterable types. To 
 
 There are cases where you don't want to collapse all literals. It often happens when you have lots of global variables and long functions, or if you want to apply different pragma patterns to different parts of the function. Fine control is possible with the ``explicit_only`` argument. When True, only explicit keyword arguments and the value of the ``function_globals`` argument (itself a dictionary) are collapsed.
 
+``pragma`` is capable of logical and mathematical deduction, meaning that expressions with unknowns can be collapsed if the known elements determine the result. For example, ``False and anything`` is logically equivalent to ``False``. ``True or anything`` is always ``True``. Mathematical: ``anything ** 0`` -> ``1``. ``0 * anything`` -> ``0``.
+
 .. todo:: Always commit changes within a block, and only mark values as non-deterministic outside of conditional blocks
 .. todo:: Support list/set/dict comprehensions
 .. todo:: Attributes are too iffy, since properties abound, but assignment to a known index of a known indexable should be remembered

--- a/docs/collapse_literals.rst
+++ b/docs/collapse_literals.rst
@@ -43,7 +43,7 @@ If a branch is constant, and thus known at decoration time, then only the correc
 
 This decorator is actually very powerful, understanding any definition-time known collections, primitives, or even dictionaries. Subscripts are resolved if the list or dictionary, and the key into it, can be resolved. Names are replaced by their values if they are not containers (since re-writing a container, such as a tuple or list, could duplicate object references). Functions, such as ``len`` and ``sum`` can be computed and replaced with their value if their arguments are known.
 
-Only primitive types are resolved, and this does not include iterable types. To control this behavior, use the `collapse_iterables` argument. Example:
+Only primitive types are resolved, and this does not include iterable types. To control this behavior, use the ``collapse_iterables`` argument. Example::
 
     v = [1, 2]
 
@@ -62,7 +62,7 @@ Only primitive types are resolved, and this does not include iterable types. To 
     def f():
         yield [1, 2]
 
-There are cases where you don't want to collapse all literals. It often happens when you have lots of global variables and long functions, or if you want to apply different pragma patterns to different parts of the function. Fine control is possible with the `explicit_only` argument. When True, only explicit keyword arguments and the value of the `function_globals` argument (itself a dictionary) are collapsed.
+There are cases where you don't want to collapse all literals. It often happens when you have lots of global variables and long functions, or if you want to apply different pragma patterns to different parts of the function. Fine control is possible with the ``explicit_only`` argument. When True, only explicit keyword arguments and the value of the ``function_globals`` argument (itself a dictionary) are collapsed.
 
 .. todo:: Always commit changes within a block, and only mark values as non-deterministic outside of conditional blocks
 .. todo:: Support list/set/dict comprehensions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/pragma/collapse_literals.py
+++ b/pragma/collapse_literals.py
@@ -36,12 +36,12 @@ class CollapseTransformer(TrackedContextTransformer):
     def visit_Subscript(self, node):
         return self.resolve_literal(self.generic_visit(node))
 
-    def _visit_AssignSubscriptTarget(self, target):
+    def _visit_Assign_withSubscriptLHS(self, target):
         def resolve_attr_of_slice(attr):
             old_val = getattr(target.slice, attr)
             if old_val is None:
                 return
-            new_val = self.resolve_literal(self.generic_visit(old_val))
+            new_val = self.visit(old_val)
             setattr(target.slice, attr, new_val)
         if isinstance(target.slice, ast.Index):
             resolve_attr_of_slice('value')
@@ -55,12 +55,12 @@ class CollapseTransformer(TrackedContextTransformer):
     def visit_Assign(self, node):
         for it, target in enumerate(node.targets):
             if isinstance(target, ast.Subscript):
-                self._visit_AssignSubscriptTarget(target)
+                self._visit_Assign_withSubscriptLHS(target)
         return super().visit_Assign(node)
 
     def visit_AugAssign(self, node):
         if isinstance(node.target, ast.Subscript):
-            self._visit_AssignSubscriptTarget(node.target)
+            self._visit_Assign_withSubscriptLHS(node.target)
         return super().visit_AugAssign(node)
 
     def visit_Call(self, node):

--- a/pragma/collapse_literals.py
+++ b/pragma/collapse_literals.py
@@ -43,6 +43,8 @@ class CollapseTransformer(TrackedContextTransformer):
                 return
             new_val = self.visit(old_val)
             setattr(target.slice, attr, new_val)
+
+        target.value = self.generic_visit(target.value)
         if isinstance(target.slice, ast.Index):
             resolve_attr_of_slice('value')
         elif isinstance(target.slice, ast.Slice):

--- a/pragma/core/resolve/literal.py
+++ b/pragma/core/resolve/literal.py
@@ -292,7 +292,7 @@ def resolve_literal_boolop(node, ctxt):
         else:
             new_values.append(val)
     # Case where everything was literal
-    if len(new_values) == 0:
+    if not new_values:
         if isinstance(node.op, ast.Or):
             return False
         elif isinstance(node.op, ast.And):

--- a/pragma/core/resolve/literal.py
+++ b/pragma/core/resolve/literal.py
@@ -247,7 +247,7 @@ def resolve_literal_binop(node, ctxt):
                     and right == 1):
                 return left
             if (isinstance(node.op, ast.Sub) and left == 0):
-                return ast.UnaryOp(ast.USub(), operand=right)
+                return ast.UnaryOp(op=ast.USub(), operand=right)
             if (isinstance(node.op, ast.Sub) and right == 0):
                 return left
 

--- a/pragma/core/resolve/literal.py
+++ b/pragma/core/resolve/literal.py
@@ -104,6 +104,8 @@ def _resolve_literal(node, ctxt):
         return resolve_literal_unop(node, ctxt)
     elif isinstance(node, ast.BinOp):
         return resolve_literal_binop(node, ctxt)
+    elif isinstance(node, ast.BoolOp):
+        return resolve_literal_boolop(node, ctxt)
     elif isinstance(node, ast.Compare):
         return resolve_literal_compare(node, ctxt)
     elif isinstance(node, ast.Call):
@@ -254,6 +256,54 @@ def resolve_literal_binop(node, ctxt):
         right = resolve_literal(node.right, ctxt)
 
         return ast.BinOp(left=left, right=right, op=node.op)
+
+
+def _is_literal_true(x):
+    return x is True or (isinstance(x, int) and bool(x) is True)
+
+def _is_literal_false(x):
+    return x is False or (isinstance(x, int) and bool(x) is False)
+
+@_log_call
+def resolve_literal_boolop(node, ctxt):
+    if not isinstance(node.op, (ast.And, ast.Or)):
+        warnings.warn("Unrecognized BoolOp. Should be And or Or, but got {}".format(node.op))
+        return node
+    values = [_resolve_literal(vast, ctxt) for vast in node.values]
+    new_values = []
+    for val in values:
+        if isinstance(node.op, ast.Or):
+            if _is_literal_true(val):  # x + 1 = 1
+                return True
+            elif _is_literal_false(val):  # x + 0 = x
+                continue
+        elif isinstance(node.op, ast.And):
+            if _is_literal_true(val):  # x * 1 = x
+                continue
+            elif _is_literal_false(val):  # x * 0 = 0
+                return False
+        for already_accounted in new_values:  # x + x = x
+            try:
+                # AST equality is challenging. Right now, this only works with name constants
+                if val.id == already_accounted.id:
+                    break
+            except AttributeError:
+                pass
+        else:
+            new_values.append(val)
+    # Case where everything was literal
+    if len(new_values) == 0:
+        if isinstance(node.op, ast.Or):
+            return False
+        elif isinstance(node.op, ast.And):
+            return True
+    # Case where we got it down to one, so the BoolOp can go away
+    elif len(new_values) == 1:
+        return new_values[0]
+    # Case where we still need BoolOp
+    else:
+        node.values = new_values
+        return node
 
 
 @_log_call

--- a/pragma/core/transformer.py
+++ b/pragma/core/transformer.py
@@ -358,7 +358,7 @@ class TrackedContextTransformer(DebugTransformerMixin, ast.NodeTransformer):
 def make_function_transformer(transformer_type, name, description, **transformer_kwargs):
     @optional_argument_decorator
     @magic_contract
-    def transform(return_source=False, save_source=True, function_globals=None, collapse_iterables=False, explicit_only=False, **kwargs):
+    def transform(return_source=False, save_source=True, function_globals=None, collapse_iterables=False, explicit_only=False, unroll_targets=None, unroll_info=None, **kwargs):
         """
         :param return_source: Returns the transformed function's source code instead of compiling it
         :type return_source: bool
@@ -396,6 +396,8 @@ def make_function_transformer(transformer_type, name, description, **transformer
             # print({k: v for k, v in glbls.items() if k not in globals()})
             trans = transformer_type(DictStack(glbls, kwargs), **transformer_kwargs)
             trans.collapse_iterables = collapse_iterables
+            trans.unroll_targets = unroll_targets
+            trans.unroll_info = unroll_info
             f_mod.body[0].decorator_list = []
             f_mod = trans.visit(f_mod)
             # print(astor.dump_tree(f_mod))

--- a/pragma/core/transformer.py
+++ b/pragma/core/transformer.py
@@ -370,6 +370,10 @@ def make_function_transformer(transformer_type, name, description, **transformer
         :type collapse_iterables: bool
         :param explicit_only: Whether to use global variables or just keyword and function_globals in the replacement context
         :type explicit_only: bool
+        :param unroll_targets: Explicit names of targets to unroll. If none, all loops will be unrolled.
+        :type unroll_targets: str|list|None
+        :param unroll_in_tiers: Information about unrolling in tiers: (iterable_name, length_of_loop, number_of_inner_iterations)
+        :type unroll_in_tiers: tuple|None
         :param kwargs: Any other environmental variables to provide during unrolling
         :type kwargs: dict
         :return: The transformed function, or its source code if requested

--- a/pragma/core/transformer.py
+++ b/pragma/core/transformer.py
@@ -358,7 +358,7 @@ class TrackedContextTransformer(DebugTransformerMixin, ast.NodeTransformer):
 def make_function_transformer(transformer_type, name, description, **transformer_kwargs):
     @optional_argument_decorator
     @magic_contract
-    def transform(return_source=False, save_source=True, function_globals=None, collapse_iterables=False, explicit_only=False, unroll_targets=None, unroll_info=None, **kwargs):
+    def transform(return_source=False, save_source=True, function_globals=None, collapse_iterables=False, explicit_only=False, unroll_targets=None, unroll_in_tiers=None, **kwargs):
         """
         :param return_source: Returns the transformed function's source code instead of compiling it
         :type return_source: bool
@@ -397,7 +397,7 @@ def make_function_transformer(transformer_type, name, description, **transformer
             trans = transformer_type(DictStack(glbls, kwargs), **transformer_kwargs)
             trans.collapse_iterables = collapse_iterables
             trans.unroll_targets = unroll_targets
-            trans.unroll_info = unroll_info
+            trans.unroll_in_tiers = unroll_in_tiers
             f_mod.body[0].decorator_list = []
             f_mod = trans.visit(f_mod)
             # print(astor.dump_tree(f_mod))

--- a/pragma/unroll.py
+++ b/pragma/unroll.py
@@ -43,7 +43,10 @@ class UnrollTransformer(TrackedContextTransformer):
 
     def visit_For(self, node):
         if self.unroll_in_tiers is not None:
-            var, N, n_inner = self.unroll_in_tiers
+            try:
+                var, N, n_inner = self.unroll_in_tiers
+            except ValueError as err:
+                raise ValueError("Invalid specification of unroll_in_tiers: should be tuple(str, int, int)") from err
             if n_inner is None:
                 n_inner = 1
             if isinstance(node.iter, ast.Name) and node.iter.id == var:

--- a/pragma/unroll.py
+++ b/pragma/unroll.py
@@ -172,6 +172,8 @@ class UnrollTransformer(TrackedContextTransformer):
                 return
             new_val = self.visit(old_val)
             setattr(target.slice, attr, new_val)
+
+        target.value = self.generic_visit(target.value)
         if isinstance(target.slice, ast.Index):
             resolve_attr_of_slice('value')
         elif isinstance(target.slice, ast.Slice):

--- a/pragma/unroll.py
+++ b/pragma/unroll.py
@@ -137,9 +137,9 @@ class UnrollTransformer(TrackedContextTransformer):
                                  target=node.target, body=node.body, orelse=[])
         remainder_node = self._visit_ForFlat(remainder_node, offset=n_outer * n_inner)
 
-        ast_range_fun = ast.Name('range', ctx=ast.Load())
+        ast_range_fun = ast.Name(id='range', ctx=ast.Load())
         ast_range_args = [ast.Num(outer_iterable.start), ast.Num(outer_iterable.stop), ast.Num(outer_iterable.step)]
-        ast_range_call = ast.Call(ast_range_fun, args=ast_range_args, keywords=[])
+        ast_range_call = ast.Call(func=ast_range_fun, args=ast_range_args, keywords=[])
 
         outer_node = ast.For(iter=ast_range_call,
                              target=ast.Name(id='PRAGMA_iouter', ctx=ast.Store()), body=inner_node, orelse=[])

--- a/pragma/unroll.py
+++ b/pragma/unroll.py
@@ -26,10 +26,10 @@ def has_break(node):
 # noinspection PyPep8Naming
 class UnrollTransformer(TrackedContextTransformer):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.loop_vars = []
         self.unroll_targets = None
         self.unroll_in_tiers = None
+        super().__init__(*args, **kwargs)
+        self.loop_vars = []
 
     def _names(self, node):
         if isinstance(node, ast.Name):

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -566,3 +566,20 @@ class TestCollapseLiterals(PragmaTest):
             x = a
         '''
         self.assertSourceEqual(f, result)
+
+    def test_mathematical_deduction(self):
+        @pragma.collapse_literals
+        def f(x):
+            yield (x / 1) + 0
+            yield 0 - x
+            yield 0 * (x ** 2 + 3*x - 2)
+            yield 0 % x
+
+        result = '''
+        def f(x):
+            yield x
+            yield -x
+            yield 0
+            yield 0
+        '''
+        self.assertSourceEqual(f, result)

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -567,6 +567,31 @@ class TestCollapseLiterals(PragmaTest):
         '''
         self.assertSourceEqual(f, result)
 
+
+    def test_logical_deduction(self):
+        @pragma.collapse_literals
+        def f(x):
+            yield x or True
+            if x and False:
+                unreachable
+            if x or 10:
+                yield 2
+            if 0 or x:
+                yield 3
+            if x or x or x or x:
+                yield 4
+
+        result = '''
+        def f(x):
+            yield 1
+            yield 2
+            if x:
+                yield 3
+            if x:
+                yield 4
+        '''
+        self.assertSourceEqual(f, result)
+
     def test_mathematical_deduction(self):
         @pragma.collapse_literals
         def f(x):

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -1,5 +1,6 @@
 # file deepcode ignore E0602: Ignore undefined variables because they never go live if just converting function string
 # file deepcode ignore E0102: Ignore function names that are redefined, such as f(x)
+# file deepcode ignore W0104: Ignore no effects
 from textwrap import dedent
 
 import pragma

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -544,6 +544,20 @@ class TestCollapseLiterals(PragmaTest):
         self.assertSourceEqual(f, result)
         self.assertSourceEqual(pragma.collapse_literals(f), result)
 
+    def test_slice_assign_(self):
+        a = [1]
+        @pragma.collapse_literals
+        def f():
+            x[a[0]] = 0
+            x[a[0]][a, b] = 1
+
+        result = '''
+        def f():
+            x[1] = 0
+            x[1][a, b] = 1
+        '''
+        self.assertSourceEqual(f, result)
+
     def test_explicit_collapse(self):
         a = 2
         b = 3
@@ -566,7 +580,6 @@ class TestCollapseLiterals(PragmaTest):
             x = a
         '''
         self.assertSourceEqual(f, result)
-
 
     def test_logical_deduction(self):
         @pragma.collapse_literals

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -603,7 +603,7 @@ class TestUnroll(PragmaTest):
 
         result = '''
         def f():
-            for PRAGMA_iouter in [0, 2, 4]:
+            for PRAGMA_iouter in range(0, 6, 2):
                 yield a[PRAGMA_iouter]
                 yield a[PRAGMA_iouter + 1]
             yield a[6]

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -604,7 +604,7 @@ class TestUnroll(PragmaTest):
         result = '''
         def f():
             for PRAGMA_iouter in [0, 2, 4]:
-                yield a[PRAGMA_iouter + 0]
+                yield a[PRAGMA_iouter]
                 yield a[PRAGMA_iouter + 1]
             yield a[6]
         '''

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -596,7 +596,7 @@ class TestUnroll(PragmaTest):
     def test_autotier_basic(self):
         a = list(range(0, 7))
 
-        @pragma.unroll(unroll_info=('PRAGMArange', len(a), 2))
+        @pragma.unroll(unroll_in_tiers=('PRAGMArange', len(a), 2))
         def f():
             for i in PRAGMArange:
                 yield a[i]
@@ -615,7 +615,7 @@ class TestUnroll(PragmaTest):
         a = list(range(0, 7))
 
         for L in [4, 7, 100]:
-            @pragma.unroll(unroll_info=('PRAGMArange', len(a), L))
+            @pragma.unroll(unroll_in_tiers=('PRAGMArange', len(a), L))
             def f():
                 for i in PRAGMArange:
                     yield a[i]


### PR DESCRIPTION
## Tiered unrolling
Partial unrolling for inner loops. It is impractical to completely unroll extremely long loops. Partial unrolling can remove some of the goto overhead while keeping the program memory footprint reasonable.

## Deduction
`False and anything` -> `False`. `0 * anything` -> `0`. And so on

## Collapse slice arguments when unrolling
This is useful when iterating over something in a permuted order. For example

```python
permutation_list = [1,2,0]
@pragma.unroll
def f():
    for i in range(3):
        x[permutation_list[i]] = i
```
becomes
```
def f():
    x[1] = 0
    x[2] = 1
    x[0] = 2
```