### PR TITLE
Pdb fixups

### DIFF
--- a/pragma/core/resolve/__init__.py
+++ b/pragma/core/resolve/__init__.py
@@ -12,8 +12,7 @@ from .. import _log_call, DictStack, _pretty_str
 log = logging.getLogger(__name__)
 
 _builtin_funcs = inspect.getmembers(builtins, lambda o: callable(o))
-pure_functions = {func for name, func in _builtin_funcs} - {print, delattr, exec, eval, input, open, setattr, super}
-
+pure_functions = {func for name, func in _builtin_funcs} - {print, delattr, exec, eval, input, open, setattr, super, breakpoint}
 
 @_log_call
 @magic_contract

--- a/pragma/core/resolve/__init__.py
+++ b/pragma/core/resolve/__init__.py
@@ -12,7 +12,11 @@ from .. import _log_call, DictStack, _pretty_str
 log = logging.getLogger(__name__)
 
 _builtin_funcs = inspect.getmembers(builtins, lambda o: callable(o))
-pure_functions = {func for name, func in _builtin_funcs} - {print, delattr, exec, eval, input, open, setattr, super, breakpoint}
+pure_functions = {func for name, func in _builtin_funcs} - {print, delattr, exec, eval, input, open, setattr, super}
+try:
+    pure_functions.discard(breakpoint)
+except NameError:
+    pass
 
 @_log_call
 @magic_contract

--- a/pragma/core/resolve/__init__.py
+++ b/pragma/core/resolve/__init__.py
@@ -75,6 +75,8 @@ _collapse_map = {
     ast.LtE: lambda a, b: a <= b,
     ast.Gt: lambda a, b: a > b,
     ast.GtE: lambda a, b: a >= b,
+    ast.In: lambda a, b: a in b,
+    ast.NotIn: lambda a, b: a not in b,
 }
 
 try:

--- a/pragma/core/transformer.py
+++ b/pragma/core/transformer.py
@@ -427,8 +427,8 @@ def make_function_transformer(transformer_type, name, description, **transformer
                     # When there are other decorators, the co_firstlineno of *some* python distributions gets confused
                     # and thinks they will be there even when they are not written to the file, causing readline overflow
                     # So we put some empty lines to make them align
-                    temp.write('\n' * func.__code__.co_firstlineno)
                     temp.write(source)
+                    temp.write('\n' * func.__code__.co_firstlineno)
                     temp.flush()
                     temp.close()
                 return func

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -334,7 +334,8 @@ class TestCollapseLiterals(PragmaTest):
         @pragma.collapse_literals
         def f(x):
             breakpoint()
-            import pdb; pdb.set_trace()
+            import pdb
+            pdb.set_trace()
 
         result = '''
         def f(x):

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -330,6 +330,21 @@ class TestCollapseLiterals(PragmaTest):
         self.assertSourceEqual(f, result)
         self.assertEqual(f(5), 15)
 
+    def test_pdb_funcs(self):
+        @pragma.collapse_literals
+        def f(x):
+            breakpoint()
+            import pdb; pdb.set_trace()
+
+        result = '''
+        def f(x):
+            breakpoint()
+            import pdb
+            pdb.set_trace()
+        '''
+
+        self.assertSourceEqual(f, result)
+
     # # Implement the functionality to get this test to pass
     # def test_assign_to_iterable(self):
     #     @pragma.collapse_literals(return_source=True)

--- a/tests/test_collapse_literals.py
+++ b/tests/test_collapse_literals.py
@@ -637,3 +637,29 @@ class TestCollapseLiterals(PragmaTest):
             yield 0
         '''
         self.assertSourceEqual(f, result)
+
+    def test_collapse_InOp(self):
+        lst = ['a', 'b', object()]
+        dct = dict(a=1, b=2)
+
+        @pragma.collapse_literals()
+        def f():
+            if 'a' in lst:
+                yield 0
+            if 'v' in lst:
+                unreachable
+            if 'b' not in lst:
+                unreachable
+            yield dct['a']
+            if 'b' in dct:
+                yield 2
+            # if 2 in dct.values():  # TODO: support this. Problem is that values is not a pure function.
+            #     yield 2
+
+        result = '''
+        def f():
+            yield 0
+            yield 1
+            yield 2
+        '''
+        self.assertSourceEqual(f, result)


### PR DESCRIPTION
# Does not attempt to call builtin `breakpoint`

# Linenos in temporary files align with function source better

# Other unrelated
Support for `if x in y` expression collapses